### PR TITLE
Choose chain from ETH_NETWORK instead of NODE_ENV

### DIFF
--- a/webapp/app/components/providers/wallet-provider.tsx
+++ b/webapp/app/components/providers/wallet-provider.tsx
@@ -11,24 +11,24 @@ export function WalletProvider({
   children,
   initialState,
   projectId,
-  devNetwork,
+  network,
 }: {
   children: ReactNode;
   initialState?: State;
   projectId: string;
-  devNetwork: boolean;
+  network: string;
 }) {
   const config = useMemo(() => {
     return getDefaultConfig({
       appName: "zkSync Upgrade Verification Tool",
-      chains: devNetwork ? [sepolia] : [mainnet],
+      chains: network === "sepolia" ? [sepolia] : [mainnet],
       projectId,
       ssr: true,
       storage: createStorage({
         storage: cookieStorage,
       }),
     });
-  }, [projectId, devNetwork]);
+  }, [projectId, network]);
 
   return (
     <WagmiProvider config={config} initialState={initialState}>

--- a/webapp/app/root.tsx
+++ b/webapp/app/root.tsx
@@ -42,7 +42,7 @@ export default function App() {
       <WalletProvider
         initialState={walletProviderInitialState}
         projectId={env.WALLET_CONNECT_PROJECT_ID}
-        devNetwork={env.NODE_ENV === "development"}
+        network={env.ETH_NETWORK}
       >
         <ConnectRedirectProvider>
           <div className="flex min-h-screen flex-col px-10 py-10 lg:px-40">

--- a/webapp/config/env.server.ts
+++ b/webapp/config/env.server.ts
@@ -10,7 +10,7 @@ export const env = createEnv({
     ALLOW_INDEXING: z.coerce.boolean().default(false),
     DATABASE_URL: z.string(),
     LOG_LEVEL: z.enum(["debug", "info"]).default("info"),
-    NODE_ENV: NodeEnvEnum,
+    NODE_ENV: NodeEnvEnum.default("production"),
     SERVER_PORT: z.coerce.number().default(3000),
     WALLET_CONNECT_PROJECT_ID: z.string(),
     L1_RPC_URL: z.string(),

--- a/webapp/config/env.server.ts
+++ b/webapp/config/env.server.ts
@@ -27,6 +27,7 @@ export const env = createEnv({
 export const clientEnv = {
   ALLOW_INDEXING: env.ALLOW_INDEXING,
   NODE_ENV: env.NODE_ENV,
+  ETH_NETWORK: env.ETH_NETWORK,
   WALLET_CONNECT_PROJECT_ID: env.WALLET_CONNECT_PROJECT_ID,
 };
 


### PR DESCRIPTION
We were choosing what chain to used based on NODE_ENV. But for sepolia deploy we want a prod deploy pointing to sepolia. This PR chooses the chain from ETH_NETWORK env variable.